### PR TITLE
chore: release 4.1.0

### DIFF
--- a/com.ktechpit.orion.yaml
+++ b/com.ktechpit.orion.yaml
@@ -8,23 +8,22 @@ command: orion
 finish-args:
   - --device=all
   - --env=INSTALL_TYPE=flatpak
-  - --filesystem=xdg-run/gvfsd
   - --share=ipc
   - --share=network
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=wayland
   - --talk-name=org.freedesktop.FileManager1
-  - --own-name=org.mpris.MediaPlayer2.mpv.*
-  - --talk-name=org.gnome.SessionManager
   - --system-talk-name=org.freedesktop.UPower.*
 
   # download directories for convenience
-  - --filesystem=xdg-desktop
   - --filesystem=xdg-download
-  - --filesystem=xdg-music
   - --filesystem=xdg-pictures
   - --filesystem=xdg-videos
+
+  #  mpris support via dbus
+  - --own-name=org.mpris.MediaPlayer2.mpv.*
+  - --talk-name=org.gnome.SessionManager
 
 
 cleanup:
@@ -116,8 +115,8 @@ modules:
         # x86_64 – stable
         # =========================
         - type: file
-          url: https://api.snapcraft.io/api/v1/snaps/download/mxJjEy7qHbIIUwLKrkjqbuLDSG1GcR5Y_95.snap
-          sha256: 7aa39bc7bd6be1fddc52c3da38331da01ac0716cf33ba06f7f5940a5bdd1d931
+          url: https://api.snapcraft.io/api/v1/snaps/download/mxJjEy7qHbIIUwLKrkjqbuLDSG1GcR5Y_98.snap
+          sha256: 32f7e5e1deb6fe08177028cfb6571ad9ac2021021c71dc841f1b093a89769b1b
           only-arches:
             - x86_64
 
@@ -127,7 +126,8 @@ modules:
         # aarch64 – stable
         # =========================
         - type: file
-          url: https://api.snapcraft.io/api/v1/snaps/download/mxJjEy7qHbIIUwLKrkjqbuLDSG1GcR5Y_96.snap
-          sha256: 1b87d1525cd9acbd2e455527832e77f908edc115818713773c87666a1c4548b2
+          url: https://api.snapcraft.io/api/v1/snaps/download/mxJjEy7qHbIIUwLKrkjqbuLDSG1GcR5Y_97.snap
+          sha256: 19f1e7cb7ef5e7448e8fe6fd03511c704968fc869f2c41b45d6d8c75168c417c
           only-arches:
             - aarch64
+


### PR DESCRIPTION
# Orion 4.1.0 Release Notes

**Release Date:** April 10, 2026

## Player

- Player window now displays the title of the file being played (with fallback to URL filename when mpv media-title is unavailable).

## UI / UX

- Fixed top toolbar missing left margin.
- Fixed open-folder button not working inside Flatpak sandbox (bypasses dbus-send, uses QDesktopServices portal).
- Fixed stop button remaining active after download completion when "stop on complete" is enabled.
- Download items now show upload stats (total uploaded, upload speed) during both downloading and seeding states.
- Seeding status line shows: uploaded amount, upload speed, peer count, and share ratio.
- Completed status no longer persists incorrectly when re-downloading a previously completed task.

## Torrent Search

- Sort combo defaults to "seed" and browse combo defaults to "Day" on initialization.
- Search button dynamically shows "Browse" (empty query), "Search" (keyword), or "Process" (magnet/hash).
- Browse-by-period filter resets to "none" when searching by keyword.
- "Latest Torrents" quick action now sorts by date instead of seeds.
- Fixed duplicate signal connections in TorrentSearchUI causing multiple processor windows to open when processing a magnet link or hash.

## Shares

- Share feature now shows total uploaded bytes alongside upload speed and ratio.
- "Copy Magnet Link" uses the daemon-provided magnetURI (with working trackers) instead of hardcoded dead tracker URLs.

## Engine / Daemon

- Show daemon startup errors to the user via a message dialog.
- Daemon automatically re-announces to trackers/DHT every 30 seconds when a torrent has zero peers, recovering from cold-start peer discovery failures.
- Debug builds include a "Daemon Log" tab showing real-time daemon stderr, engine events, and per-progress stats.

## Peer Discovery

- Dynamic tracker list: daemon fetches an up-to-date tracker list from community-maintained sources (ngosang/trackerslist, XIU2/TrackersListCollection) on startup, falling back to the bundled list on failure.
- Automatic re-announce: torrents with zero peers re-announce to all trackers and DHT every 30 seconds, recovering from cold-start peer discovery failures.

## Bug Fixes

- Fixed Qt `connectSlotsByName` warnings for `historyTableWidget` slots (const-correctness mismatch with QTableWidget signals).
- Fixed `m_stats.seeding` flag never being set to true in the task state machine.
- Added `uploaded` field to TorrentTask::Stats and parse it from daemon progress events.
